### PR TITLE
test(rp-docs): set field_rp_node_count on alpha queue-spec fixtures

### DIFF
--- a/amp_dev.install
+++ b/amp_dev.install
@@ -703,7 +703,7 @@ function amp_dev_install_create_rp_alpha() {
       'field_rp_gpu_vram' => 80,
       'field_rp_gpus' => 'NVIDIA A100',
       'field_rp_vram' => 256,
-      'field_rp_queue_nodes' => '100',
+      'field_rp_node_count' => 100,
     ]),
     _amp_dev_create_paragraph('rp_queue_spec', [
       'field_rp_queue_name' => 'gpu-large',
@@ -714,7 +714,7 @@ function amp_dev_install_create_rp_alpha() {
       'field_rp_gpu_vram' => 80,
       'field_rp_gpus' => 'NVIDIA A100',
       'field_rp_vram' => 512,
-      'field_rp_queue_nodes' => '20',
+      'field_rp_node_count' => 20,
     ]),
     _amp_dev_create_paragraph('rp_queue_spec', [
       'field_rp_queue_name' => 'cpu-shared',
@@ -724,7 +724,7 @@ function amp_dev_install_create_rp_alpha() {
       'field_rp_gpu_count' => 0,
       'field_rp_gpus' => '',
       'field_rp_vram' => 256,
-      'field_rp_queue_nodes' => '200',
+      'field_rp_node_count' => 200,
     ]),
   ];
 


### PR DESCRIPTION
Replace the dead field_rp_queue_nodes string reference (a field that was never created) with the real integer field_rp_node_count (100/20/200) on the three alpha queue specs, so the resource API and page tests can assert node counts.

Refs D8-2772