### PR TITLE
fixture(rp-docs): OOD software + max wall time on Alpha test resource

### DIFF
--- a/amp_dev.install
+++ b/amp_dev.install
@@ -704,6 +704,7 @@ function amp_dev_install_create_rp_alpha() {
       'field_rp_gpus' => 'NVIDIA A100',
       'field_rp_vram' => 256,
       'field_rp_node_count' => 100,
+      'field_rp_max_wall_time' => 48,
     ]),
     _amp_dev_create_paragraph('rp_queue_spec', [
       'field_rp_queue_name' => 'gpu-large',
@@ -715,6 +716,9 @@ function amp_dev_install_create_rp_alpha() {
       'field_rp_gpus' => 'NVIDIA A100',
       'field_rp_vram' => 512,
       'field_rp_node_count' => 20,
+      // 120h limit that recent usage exceeds (some days in the 30-day window ran longer,
+      // e.g. before the limit was lowered) — demonstrates the trend crossing the max line.
+      'field_rp_max_wall_time' => 120,
     ]),
     _amp_dev_create_paragraph('rp_queue_spec', [
       'field_rp_queue_name' => 'cpu-shared',
@@ -788,6 +792,16 @@ function amp_dev_install_create_rp_alpha() {
       'format' => 'full_html',
     ],
     'field_rp_top_software' => $top_software,
+    // Students enter only names; OodSoftwareService enriches from SDS on cron.
+    // These literals mirror the SDS-enriched output (not hand-authored copy) so
+    // CI is deterministic without a live SDS call. Cron overwrites in real envs.
+    'field_rp_ood_software' => [
+      'value' => json_encode([
+        ['name' => 'Jupyter', 'description' => 'Jupyter is an open-source web application that allows you to create and share documents that contain live code, equations, visualizations, and narrative text. It supports over 40 programming languages, including Python, R, and Julia, and is widely used in data science, scientific computing, and machine learning projects.', 'research_field' => 'Computer & Information Sciences', 'web_page' => 'https://jupyter.org/', 'documentation' => 'https://docs.jupyter.org/en/latest/'],
+        ['name' => 'RStudio', 'description' => 'RStudio is an integrated development environment (IDE) for R, a programming language and environment widely used for statistical computing and graphics. RStudio provides an intuitive and productive user interface for R, allowing users to efficiently write, execute, and debug R code.', 'research_field' => 'Other Natural Sciences', 'web_page' => 'https://posit.co/products/open-source/rstudio/', 'documentation' => 'https://docs.posit.co/ide/user/'],
+      ]),
+      'format' => 'full_html',
+    ],
     'field_rp_jobs_info' => [
       'value' => '<p>Alpha uses Slurm for job scheduling. Jobs are submitted via <code>sbatch</code> and monitored with <code>squeue</code>. GPU jobs must specify the number of GPUs with <code>--gres=gpu:N</code>.</p>',
       'format' => 'full_html',
@@ -798,6 +812,37 @@ function amp_dev_install_create_rp_alpha() {
     ],
     'field_rp_listing' => TRUE,
     'field_domain_access' => ['amp_cyberinfrastructure_org'],
+    // Mock queue metrics: gpu-standard spark_max ~60h (48h limit fits inside SVG);
+    // cpu-shared included but has no max_wall_time set.
+    'field_rp_queue_metrics' => json_encode([
+      'updated' => '2 hours ago',
+      'queues' => [
+        'gpu-standard' => [
+          'job_count' => 1250,
+          'wait_time' => 2.3,
+          'wall_time' => 22.4,
+          'daily_wait' => [1.2, 2.1, 1.8, 2.5, 1.9, 2.2, 1.7, 2.0, 2.3, 1.5, 2.1, 1.9, 2.4, 2.2, 1.8, 2.0, 2.3, 2.1, 1.7, 2.2, 2.0, 1.8, 2.3, 2.1, 1.9, 2.2, 2.0, 1.8, 2.1, 1.9],
+          // Normal case: usage stays below the 48h max, so the max line sits just above the trend's peak (~44h).
+          'daily_wall' => [3.2, 18.5, 41.1, 9.8, 31.2, 2.6, 43.7, 15.4, 28.9, 6.0, 44.2, 12.8, 22.1, 38.3, 5.7, 33.1, 19.5, 42.6, 8.7, 25.2, 14.4, 40.1, 3.5, 29.6, 17.9, 39.7, 7.3, 21.8, 43.9, 11.5],
+        ],
+        'gpu-large' => [
+          'job_count' => 380,
+          'wait_time' => 4.5,
+          'wall_time' => 71.6,
+          'daily_wait' => [3.8, 4.2, 5.1, 4.7, 3.9, 4.4, 5.0, 4.3, 3.7, 4.6, 5.2, 4.1, 3.9, 4.8, 5.3, 4.0, 3.8, 4.5, 5.1, 4.2, 3.9, 4.7, 5.0, 4.3, 3.8, 4.5, 5.2, 4.1, 3.9, 4.6],
+          // gpu-large: wide spread with a peak (~150h) that exceeds the 120h max, so the trend crosses the max line.
+          'daily_wall' => [12.5, 88.3, 41.2, 150.1, 22.7, 105.4, 58.9, 133.2, 8.4, 96.1, 44.7, 118.5, 31.2, 142.8, 19.6, 77.3, 51.5, 128.2, 26.0, 149.5, 35.8, 92.1, 63.6, 115.4, 17.0, 137.8, 48.2, 101.0, 29.6, 124.7],
+        ],
+        'cpu-shared' => [
+          'job_count' => 4200,
+          'wait_time' => 0.8,
+          'wall_time' => 5.4,
+          'daily_wait' => [0.6, 0.7, 0.9, 0.8, 0.7, 0.8, 0.9, 0.7, 0.6, 0.8, 0.9, 0.7, 0.6, 0.8, 0.9, 0.8, 0.7, 0.8, 0.9, 0.7, 0.6, 0.8, 0.9, 0.7, 0.8, 0.8, 0.9, 0.7, 0.6, 0.8],
+          // cpu-shared: no max wall time; spread from near-zero to ~11h.
+          'daily_wall' => [1.2, 8.4, 3.6, 10.8, 2.1, 6.9, 4.3, 9.5, 0.8, 7.2, 3.9, 11.1, 2.5, 8.8, 1.6, 5.7, 4.0, 10.2, 2.9, 9.1, 1.4, 6.5, 3.3, 10.5, 2.2, 7.8, 4.6, 9.0, 1.9, 6.2],
+        ],
+      ],
+    ]),
   ];
 
   if ($node) {


### PR DESCRIPTION
Add field_rp_ood_software (Jupyter, RStudio) and per-queue field_rp_max_wall_time to the Alpha fixture. OOD values mirror SDS-enriched output so CI is deterministic without a live SDS call, the same pattern top_software already uses. Queue metrics tuned so one queue's trend stays under its limit and another crosses it, exercising the sparkline limit line both ways.